### PR TITLE
Uso de raw para los textos de resumen porque pueden contener entidades H...

### DIFF
--- a/app/views/news_tematica/news_tematicas/_bloque_foro.html.haml
+++ b/app/views/news_tematica/news_tematicas/_bloque_foro.html.haml
@@ -10,4 +10,4 @@
       %td.texto
         %h5.titulo= link_to_con_estadisticas tema.titulo, tema.contenido_dominio_link, @news_tematica
         %span.nombre_usuario= link_to_con_estadisticas usuario.nick, perfil_url(usuario.nick_limpio), @news_tematica
-        %p.resumen= tema.descripcion
+        %p.resumen= raw tema.descripcion

--- a/app/views/news_tematica/news_tematicas/_bloque_mas_leidos.html.haml
+++ b/app/views/news_tematica/news_tematicas/_bloque_mas_leidos.html.haml
@@ -8,5 +8,5 @@
       %td.texto
         %h5.titulo= link_to_con_estadisticas masleido.titulo, masleido.contenido_dominio_link, @news_tematica
         %p.resumen
-          = masleido.descripcion
+          = raw masleido.descripcion
           = link_to_con_estadisticas 'Leer más >>', masleido.contenido_dominio_link, @news_tematica, class: 'leer_mas'

--- a/app/views/news_tematica/news_tematicas/_bloque_otros_titulares.html.haml
+++ b/app/views/news_tematica/news_tematicas/_bloque_otros_titulares.html.haml
@@ -10,5 +10,5 @@
           %td.texto{ colspan: foto ? nil : 2, class: foto ? 'con_foto' : nil }
             %h5.titulo= link_to_con_estadisticas titular.titulo, titular.contenido_dominio_link, @news_tematica
             %p.resumen
-              = max_caracteres_con_palabras_enteras(titular.descripcion, 150)
+              = raw max_caracteres_con_palabras_enteras(titular.descripcion, 150)
               = link_to_con_estadisticas 'Leer&nbsp;más&nbsp;>>'.html_safe, titular.contenido_dominio_link, @news_tematica, class: 'leer_mas'

--- a/app/views/news_tematica/news_tematicas/_bloque_titulares.html.haml
+++ b/app/views/news_tematica/news_tematicas/_bloque_titulares.html.haml
@@ -10,5 +10,5 @@
       %td.texto{ colspan: foto ? nil : 2 }
         %h5.titulo= link_to_con_estadisticas titular.titulo, titular.contenido_dominio_link, @news_tematica
         %p.resumen
-          = titular.descripcion
+          = raw titular.descripcion
           = link_to_con_estadisticas 'Leer más >>', titular.contenido_dominio_link, @news_tematica, class: 'leer_mas'


### PR DESCRIPTION
...TML que no han de convertirse a texto.
