### PR TITLE
Arreglo tags sendgrid

### DIFF
--- a/app/controllers/news_tematica/news_tematicas_controller.rb
+++ b/app/controllers/news_tematica/news_tematicas_controller.rb
@@ -39,7 +39,7 @@ module NewsTematica
 
     def preview
       carga_variables_preview NewsTematica.find(params[:id])
-      render 'news_tematica/news_tematicas/_preview', layout: false
+      render text: dame_html, layout: false
     end
 
     def edit


### PR DESCRIPTION
Premailer convierte los `[` y `]` contenidos en `href` por sus entidades html (`%5B` y `%5D`), de modo que Sendgrid no los detectaba como tags de sustitución y no añadía los enlaces donde toca.
