### PR TITLE
News aplazadas

### DIFF
--- a/app/controllers/news_tematica/news_tematicas_controller.rb
+++ b/app/controllers/news_tematica/news_tematicas_controller.rb
@@ -65,6 +65,11 @@ module NewsTematica
       end
     end
 
+    def destroy
+      newstematica_klass.find(params[:id]).destroy
+      redirect_to news_tematicas_path
+    end
+
     def elegir_contenidos
       @news_tematica = NewsTematicaDecorator.decorate(newstematica_klass.find(params[:id]))
       @titulo = "Elegir contenidos para la newsletter"

--- a/app/controllers/news_tematica/news_tematicas_controller.rb
+++ b/app/controllers/news_tematica/news_tematicas_controller.rb
@@ -1,5 +1,3 @@
-# coding: utf-8
-
 module NewsTematica
   class NewsTematicasController < ApplicationController
     include Clases
@@ -7,7 +5,7 @@ module NewsTematica
 
     def index
       @titulo = 'Newsletters temáticas'
-      @news_tematicas = newstematica_klass.order('fecha_envio DESC')
+      @news_tematicas = newstematica_klass.order(fecha_envio: :desc).paginate(page: params[:page], per_page: 20)
     end
 
     def show

--- a/app/controllers/news_tematica/news_tematicas_controller.rb
+++ b/app/controllers/news_tematica/news_tematicas_controller.rb
@@ -35,11 +35,6 @@ module NewsTematica
       end
     end
 
-    def preview
-      carga_variables_preview newstematica_klass.find(params[:id])
-      render text: dame_html, layout: false
-    end
-
     def edit
       @news_tematica = newstematica_klass.find(params[:id])
       @titulo = "Editar newsletter '#{ @news_tematica.nombre }'"

--- a/app/models/news_tematica/news_tematica.rb
+++ b/app/models/news_tematica/news_tematica.rb
@@ -45,7 +45,7 @@ module NewsTematica
     end
 
     def self.nueva_con_fechas_por_defecto(tematica_id)
-      new(tematica_id: tematica_id, fecha_hasta: Time.zone.now, fecha_envio: 6.hours.from_now)
+      new(tematica_id: tematica_id, fecha_hasta: Time.zone.now, fecha_envio: 1.year.from_now)
     end
 
     private

--- a/app/views/news_tematica/news_tematicas/edit.html.haml
+++ b/app/views/news_tematica/news_tematicas/edit.html.haml
@@ -6,11 +6,11 @@
 = form_for @news_tematica do |f|
   %table
     = campo f, 'titulo', class: 'grande'
-    = campo f, 'fecha_envio', tipo: 'datetime', label: 'Fecha&nbsp;envío', tr_style: 'height: 40px'
     %tr
       %th
       %td.flota_der= link_to('Seleccionar contenidos', elegir_contenidos_news_tematica_path(@news_tematica), title: 'Permite seleccionar los titulares y mensajes que van a ser incluidos en la newsletter, quitando los duplicados y/o que no interesen.', style: 'margin-right: 10px')
     = campo f, 'html', tipo: 'area', autofocus: true, tr_style: 'vertical-align: top'
+    = campo f, 'fecha_envio', tipo: 'datetime', label: 'Fecha&nbsp;envío', tr_style: 'height: 40px'
     %tr
       %th
       %td

--- a/app/views/news_tematica/news_tematicas/index.html.haml
+++ b/app/views/news_tematica/news_tematicas/index.html.haml
@@ -2,11 +2,12 @@
 
 - unless @news_tematicas.blank?
   %table.ranking
-    = ths(%w(Título Temática fecha_envío enviada))
+    = ths(%w(Título Temática fecha_envío enviada -))
     - @news_tematicas.each do |news_tematica|
       %tr{ class: news_tematica.enviada ? 'par' : nil }
         %td= link_to news_tematica.titulo, edit_news_tematica_path(news_tematica)
         %td= news_tematica.nombre
         %td= l news_tematica.fecha_envio, format: :short
         %td.center= news_tematica.enviada ? 'Sí' : 'No'
+        %td= link_to('Borrar', news_tematica_path(news_tematica), method: :delete, data: { confirm: "¿Borrar la newsletter #{ news_tematica.titulo }?" })
 

--- a/app/views/news_tematica/news_tematicas/index.html.haml
+++ b/app/views/news_tematica/news_tematicas/index.html.haml
@@ -11,3 +11,4 @@
         %td.center= news_tematica.enviada ? 'Sí' : 'No'
         %td= link_to('Borrar', news_tematica_path(news_tematica), method: :delete, data: { confirm: "¿Borrar la newsletter #{ news_tematica.titulo }?" })
 
+= will_paginate @news_tematicas

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,5 @@ NewsTematica::Engine.routes.draw do
   resources :news_tematicas do
     post :contenidos_elegidos, on: :member
     get :elegir_contenidos, on: :member
-    get :preview, on: :member
   end
 end

--- a/lib/news_tematica.rb
+++ b/lib/news_tematica.rb
@@ -3,6 +3,7 @@ require 'draper'
 require 'haml'
 require 'coffee-rails'
 require 'jquery-rails'
+require 'will_paginate'
 
 module NewsTematica
   module Clases

--- a/news_tematica.gemspec
+++ b/news_tematica.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
   # Gema para transformar bello HTML y CSS en odioso código para emails
   s.add_dependency 'premailer-rails'
   s.add_dependency 'nokogiri'
+  s.add_dependency 'will_paginate'
 
   s.add_dependency 'haml-rails'
   s.add_dependency 'sass'


### PR DESCRIPTION
Adding `destroy`, deleting `preview` (unused and even unlinked, we've on-screen preview with the `show`, and we also can send previews by email) and improving `index` (with pagination), new (with a safer far-future "fecha envío") and edit (showing the "fecha envío" near the "Enviar" button, also safer)