### PR TITLE
News aplazadas 2

### DIFF
--- a/app/controllers/news_tematica/news_tematicas_controller.rb
+++ b/app/controllers/news_tematica/news_tematicas_controller.rb
@@ -49,7 +49,7 @@ module NewsTematica
         @news_tematica.enviar_preview_a!(@yo)
         flash[:notice] = "Correo de prueba enviado a #{ @yo.email }"
         render('edit')
-      else 
+      else
         @news_tematica.update_attributes(news_tematica_params) or return(render('edit'))
         redirect_to news_tematicas_path
       end

--- a/app/controllers/news_tematica/news_tematicas_controller.rb
+++ b/app/controllers/news_tematica/news_tematicas_controller.rb
@@ -49,13 +49,9 @@ module NewsTematica
         @news_tematica.enviar_preview_a!(@yo)
         flash[:notice] = "Correo de prueba enviado a #{ @yo.email }"
         render('edit')
-      elsif !@news_tematica.update_attributes(news_tematica_params)
-        render('edit')
-      elsif params[:commit].downcase.include?('mandrill')
-        @news_tematica.enviar!
+      else 
+        @news_tematica.update_attributes(news_tematica_params) or return(render('edit'))
         redirect_to news_tematicas_path
-      else
-        redirect_to(edit_news_tematica_path(@news_tematica))
       end
     end
 

--- a/app/controllers/news_tematica/news_tematicas_controller.rb
+++ b/app/controllers/news_tematica/news_tematicas_controller.rb
@@ -44,11 +44,12 @@ module NewsTematica
       @titulo = "Editar newsletter '#{ @news_tematica.nombre }'"
       if @news_tematica.enviada
         render(text: 'Esta newsletter ya ha sido enviada, no puede modificarse ni volverse a enviar.')
-      elsif !@news_tematica.update_attributes(news_tematica_params)
-        render('edit')
       elsif params[:commit].downcase =~ /prueba|preview/
+        @news_tematica.assign_attributes(news_tematica_params)
         @news_tematica.enviar_preview_a!(@yo)
         flash[:notice] = "Correo de prueba enviado a #{ @yo.email }"
+        render('edit')
+      elsif !@news_tematica.update_attributes(news_tematica_params)
         render('edit')
       elsif params[:commit].downcase.include?('mandrill')
         @news_tematica.enviar!

--- a/app/views/news_tematica/news_tematicas/edit.html.haml
+++ b/app/views/news_tematica/news_tematicas/edit.html.haml
@@ -17,9 +17,8 @@
         - if @news_tematica.enviada
           %p Esta newsletter ya ha sido enviada, no puede modificarse ni volverse a enviar.
         - else
-          = submit_tag('Guardar', class: 'boton_reborde_naranja_grande')
           = submit_tag('Enviarme correo de prueba', class: 'boton_reborde_naranja_grande')
-          = submit_tag('Enviar vía Mandrill', class: 'boton_azul_claro_reborde', onclick: "return confirm('¿Enviar a Mandrill?');")
+          = submit_tag('Guardar y enviar vía Mandrill', class: 'boton_azul_claro_reborde', onclick: "return confirm('¿Enviar a Mandrill?');")
 
 = javascript_include_tag 'http://www.rankia.com/ckeditor/ckeditor.js'
 :javascript

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,5 @@
+[9.0.0] Now "sending" a newsletter doesn't send it, but leaves it scheduled to send by cron tasks
+        Sending preview doesn't save the newsletter, avoiding unintended schedules that could be eventually launched
 [8.2.0] Added the "delete newsletter" feature
         Deleted the unused, and even unlinked, "preview" feature; we can preview on the web with "show"
         Newsletters are created with far-future sending date

--- a/lib/news_tematica/version.rb
+++ b/lib/news_tematica/version.rb
@@ -1,3 +1,3 @@
 module NewsTematica
-  VERSION = '8.2.0'
+  VERSION = '9.0.0'
 end

--- a/spec/controllers/news_tematica/news_tematicas_controller_spec.rb
+++ b/spec/controllers/news_tematica/news_tematicas_controller_spec.rb
@@ -129,11 +129,12 @@ describe NewsTematica::NewsTematicasController, type: :controller do
       expect(mi_news_tematica.titulo).not_to eq 'Cambio'
     end
 
-    it "debe permitir cambiar news no enviadas" do
+    it 'debe permitir cambiar news no enviadas si se ha usado el botón de Guardar y Enviar y todo está bien' do
+      expect_any_instance_of(NewsTematica::NewsTematica).not_to receive(:enviar!)
       post :update, id: mi_news_tematica.id, news_tematica: { titulo: 'Cambio' }
       mi_news_tematica.reload
       expect(mi_news_tematica.titulo).to eq 'Cambio'
-      expect(response).to redirect_to edit_news_tematica_path(mi_news_tematica)
+      expect(response).to redirect_to news_tematicas_path
     end
 
     it "debe editar de nuevo si falla al guardar" do
@@ -150,14 +151,6 @@ describe NewsTematica::NewsTematicasController, type: :controller do
       expect(mi_news_tematica.titulo).not_to eq('Cambio')
       expect(assigns(:news_tematica).titulo).to eq('Cambio')
       expect(response).to render_template('news_tematicas/edit')
-    end
-
-    it 'debe llamar al envío por Mandrill si se ha usado el botón de Mandrill y todo está bien' do
-      expect_any_instance_of(NewsTematica::NewsTematica).to receive(:enviar!)
-      post :update, id: mi_news_tematica.id, news_tematica: { titulo: 'MyNews' }, commit: 'Enviar vía Mandrill'
-      mi_news_tematica.reload
-      expect(mi_news_tematica.titulo).to eq 'MyNews'
-      expect(response).to redirect_to news_tematicas_path
     end
   end
 

--- a/spec/controllers/news_tematica/news_tematicas_controller_spec.rb
+++ b/spec/controllers/news_tematica/news_tematicas_controller_spec.rb
@@ -143,6 +143,15 @@ describe NewsTematica::NewsTematicasController, type: :controller do
       expect(response).to render_template('news_tematicas/edit')
     end
 
+    it 'debe enviar preview por Mandrill pero sin guardar, si se ha usado el botón de correo de pruebas' do
+      expect_any_instance_of(NewsTematica::NewsTematica).to receive(:enviar_preview_a!)
+      post :update, id: mi_news_tematica.id, news_tematica: { titulo: 'Cambio' }, commit: 'Enviarme correo de prueba'
+      mi_news_tematica.reload
+      expect(mi_news_tematica.titulo).not_to eq('Cambio')
+      expect(assigns(:news_tematica).titulo).to eq('Cambio')
+      expect(response).to render_template('news_tematicas/edit')
+    end
+
     it 'debe llamar al envío por Mandrill si se ha usado el botón de Mandrill y todo está bien' do
       expect_any_instance_of(NewsTematica::NewsTematica).to receive(:enviar!)
       post :update, id: mi_news_tematica.id, news_tematica: { titulo: 'MyNews' }, commit: 'Enviar vía Mandrill'

--- a/test/dummy/app/controllers/application_controller.rb
+++ b/test/dummy/app/controllers/application_controller.rb
@@ -10,6 +10,7 @@ class ApplicationController < ActionController::Base
     unless soy_admin?
       envia_a_login("Debe identificarse como administrador para acceder")
     end
+    @yo = Usuario.new(nick: 'Admin', nick_limpio: 'admin', email: 'admin@estaweb.es')
   end
 
   # Impide el acceso a usuarios no gestores de usuarios


### PR DESCRIPTION
1.- "Preview" doesn't save changes (but still sends preview)
2.- Instead of two buttons, "Guardar" & "Enviar", we now have 1 button "Guardar y enviar", which in fact doesn't send, but schedules it...