### PR TITLE
Only send to active susbcriptions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem 'pg'
 gem 'paperclip'
 gem 'aws-sdk', '< 2.0'
 gem 'aws-s3', require: 'aws/s3'
-gem 'suscribir', git: 'https://github.com/Soluciones/suscribir.git', tag: '6.1.0'
+gem 'suscribir', git: 'https://github.com/Soluciones/suscribir.git', tag: '6.2.1'
 gem 'psique', '= 0.1.0'
 gem 'mandrill-api', require: 'mandrill'
 

--- a/app/models/news_tematica/news_tematica.rb
+++ b/app/models/news_tematica/news_tematica.rb
@@ -24,7 +24,7 @@ module NewsTematica
     end
 
     def enviar!
-      suscribible.suscripciones.find_in_batches do |grupo_suscripciones|
+      suscribible.suscripciones.activas.find_in_batches do |grupo_suscripciones|
         enviar_a(grupo_suscripciones)
         sleep(1)
       end

--- a/spec/controllers/news_tematica/news_tematicas_controller_spec.rb
+++ b/spec/controllers/news_tematica/news_tematicas_controller_spec.rb
@@ -5,28 +5,28 @@ describe NewsTematica::NewsTematicasController, type: :controller do
   routes { NewsTematica::Engine.routes }
 
   let!(:mi_news_tematica) do
-    FactoryGirl.create(:news_tematica, tematica: Tematica.find_by(nombre: 'Bolsa'), fecha_desde: 7.days.ago,
-                       fecha_hasta: 1.minute.ago)
+    create(:news_tematica, tematica: Tematica.find_by(nombre: 'Bolsa'),
+           fecha_desde: 7.days.ago, fecha_hasta: 1.minute.ago)
   end
   let(:dominio) { 'test.host' }
-  let(:admin) { FactoryGirl.create(:admin) }
+  let(:admin) { create(:admin) }
 
   describe "contenidos_elegidos" do
     let(:mensaje_raso) do
-      mensaje = FactoryGirl.create(:tema, created_at: 3.days.ago, titulo: 'CAF paga dividendo hoy')
-      mensaje.tap { |mensaje| FactoryGirl.create(:veces_leido, leido: mensaje, contador: 100) }
+      mensaje = create(:tema, created_at: 3.days.ago, titulo: 'CAF paga dividendo hoy')
+      mensaje.tap { |mensaje| create(:veces_leido, leido: mensaje, contador: 100) }
     end
 
     let(:titular_muy_leido) do
-      mensaje = FactoryGirl.create(:tema_titular, fecha_titulares: 1.hour.ago, created_at: 3.hours.ago,
-                                   bolsa: true, titulo: 'Gana 2% semanal')
-      mensaje.tap { |mensaje| FactoryGirl.create(:veces_leido, leido: mensaje, contador: 5000) }
+      mensaje = create(:tema_titular, fecha_titulares: 1.hour.ago, created_at: 3.hours.ago,
+                       bolsa: true, titulo: 'Gana 2% semanal')
+      mensaje.tap { |mensaje| create(:veces_leido, leido: mensaje, contador: 5000) }
     end
 
     let(:mensaje_muy_recomendado) do
-      mensaje = FactoryGirl.create(:tema, created_at: 3.days.ago, votos_count: 20, respuestas_count: 3,
-                                   titulo: 'El quinto elemento')
-      mensaje.tap { |mensaje| FactoryGirl.create(:veces_leido, leido: mensaje, contador: 100) }
+      mensaje = create(:tema, created_at: 3.days.ago, votos_count: 20, respuestas_count: 3,
+                       titulo: 'El quinto elemento')
+      mensaje.tap { |mensaje| create(:veces_leido, leido: mensaje, contador: 100) }
     end
 
     def post_contenidos_elegidos(prioridades_titulares = nil)

--- a/spec/controllers/news_tematica/news_tematicas_controller_spec.rb
+++ b/spec/controllers/news_tematica/news_tematicas_controller_spec.rb
@@ -13,20 +13,18 @@ describe NewsTematica::NewsTematicasController, type: :controller do
 
   describe "contenidos_elegidos" do
     let(:mensaje_raso) do
-      mensaje = create(:tema, created_at: 3.days.ago, titulo: 'CAF paga dividendo hoy')
-      mensaje.tap { |mensaje| create(:veces_leido, leido: mensaje, contador: 100) }
+      atributos = { created_at: 3.days.ago, titulo: 'CAF paga dividendo hoy' }
+      create(:tema, atributos).tap { |mensaje| create(:veces_leido, leido: mensaje, contador: 100) }
     end
 
     let(:titular_muy_leido) do
-      mensaje = create(:tema_titular, fecha_titulares: 1.hour.ago, created_at: 3.hours.ago,
-                       bolsa: true, titulo: 'Gana 2% semanal')
-      mensaje.tap { |mensaje| create(:veces_leido, leido: mensaje, contador: 5000) }
+      atributos = { fecha_titulares: 1.hour.ago, created_at: 3.hours.ago, bolsa: true, titulo: 'Gana 2% semanal' }
+      create(:tema_titular, atributos).tap { |mensaje| create(:veces_leido, leido: mensaje, contador: 5000) }
     end
 
     let(:mensaje_muy_recomendado) do
-      mensaje = create(:tema, created_at: 3.days.ago, votos_count: 20, respuestas_count: 3,
-                       titulo: 'El quinto elemento')
-      mensaje.tap { |mensaje| create(:veces_leido, leido: mensaje, contador: 100) }
+      atributos = { created_at: 3.days.ago, votos_count: 20, respuestas_count: 3, titulo: 'El quinto elemento' }
+      create(:tema, atributos).tap { |mensaje| create(:veces_leido, leido: mensaje, contador: 100) }
     end
 
     def post_contenidos_elegidos(prioridades_titulares = nil)

--- a/spec/decorators/news_tematica/news_tematica_decorator_spec.rb
+++ b/spec/decorators/news_tematica/news_tematica_decorator_spec.rb
@@ -8,23 +8,23 @@ describe NewsTematica::NewsTematicaDecorator do
       muchos_clics = 6
       redirection_id_pocos_clics = 124
       redirection_id_muchos_clics = 125
-      FactoryGirl.create_list(:visita, pocos_clics, redirection_id: redirection_id_pocos_clics)
-      FactoryGirl.create_list(:visita, muchos_clics, redirection_id: redirection_id_muchos_clics)
+      create_list(:visita, pocos_clics, redirection_id: redirection_id_pocos_clics)
+      create_list(:visita, muchos_clics, redirection_id: redirection_id_muchos_clics)
       link_con_pocos_clics = "<a href=\"http://midominio.com/redirections/#{redirection_id_pocos_clics}\" style=\"colorlink\">spam</a>"
       link_con_pocos_clics_con_contador = "<span class=\"cuentaclics\">#{pocos_clics}</span><a href=\"http://midominio.com/redirections/#{redirection_id_pocos_clics}\" style=\"colorlink\">spam</a>"
       link_con_muchos_clics = "<a href=\"http://midominio.com/redirections/#{redirection_id_muchos_clics}\">spam</a>"
       link_con_muchos_clics_con_contador = "<span class=\"cuentaclics\">#{muchos_clics}</span><a href=\"http://midominio.com/redirections/#{redirection_id_muchos_clics}\">spam</a>"
       html = "<p>blabla #{link_con_pocos_clics} blabla #{link_con_pocos_clics} otro mas #{link_con_muchos_clics}</p>"
       html_con_contador = "<p>blabla #{link_con_pocos_clics_con_contador} blabla #{link_con_pocos_clics_con_contador} otro mas #{link_con_muchos_clics_con_contador}</p>"
-      news_tematica = FactoryGirl.build(:news_tematica, html: html).decorate
+      news_tematica = build(:news_tematica, html: html).decorate
       expect(news_tematica.html_con_contadores).to eq html_con_contador
     end
   end
 
   describe "#prioriza_como_te_diga" do
     context "con una lista de contenidos seleccionados y unas prioridades establecidas" do
-      let(:news_tematica) { FactoryGirl.create(:news_tematica).decorate }
-      let(:contenidos_seleccionables) { FactoryGirl.create_list(:contenido, 15) }
+      let(:news_tematica) { create(:news_tematica).decorate }
+      let(:contenidos_seleccionables) { create_list(:contenido, 15) }
       let(:prioridades) do
         prioridades = {}
         contenidos_seleccionables.shuffle.each_with_index do |contenido, indice|

--- a/spec/factories/contenido.rb
+++ b/spec/factories/contenido.rb
@@ -3,10 +3,10 @@ FactoryGirl.define do
     transient do
       debo_aceptar_contenido true
     end
-    titulo          { Faker::Lorem.sentence.to_s }
+    titulo          { FFaker::Lorem.sentence.to_s }
     association     :usuario
     subtipo         { Subtipo.first || FactoryGirl.create(:subtipo) }
-    texto_completo  { Faker::Lorem.paragraphs.join('<br/><br/>') }
+    texto_completo  { FFaker::Lorem.paragraphs.join('<br/><br/>') }
     usr_nick        { usuario.nick }
     usr_nick_limpio { usuario.nick_limpio }
     es              true

--- a/spec/factories/news_tematica/news_tematica.rb
+++ b/spec/factories/news_tematica/news_tematica.rb
@@ -4,11 +4,11 @@ FactoryGirl.define do
     titulo        { "Novedades de #{ tematica.nombre }" }
     fecha_envio   { 1.day.from_now }
     html          { "<h1>Hello world!</h1>" }
-    banner_1_url_imagen { Faker::Internet.uri 'http' }
-    banner_1_texto_alt { Faker::Lorem.sentence }
-    banner_1_url_destino { Faker::Internet.uri 'http' }
-    banner_2_url_imagen { Faker::Internet.uri 'http' }
-    banner_2_texto_alt  { Faker::Lorem.sentence }
-    banner_2_url_destino { Faker::Internet.uri 'http' }
+    banner_1_url_imagen { FFaker::Internet.uri 'http' }
+    banner_1_texto_alt { FFaker::Lorem.sentence }
+    banner_1_url_destino { FFaker::Internet.uri 'http' }
+    banner_2_url_imagen { FFaker::Internet.uri 'http' }
+    banner_2_texto_alt  { FFaker::Lorem.sentence }
+    banner_2_url_destino { FFaker::Internet.uri 'http' }
   end
 end

--- a/spec/factories/subtipo.rb
+++ b/spec/factories/subtipo.rb
@@ -3,7 +3,7 @@ FactoryGirl.define do
     "#{ n }-subtipo"
   end
   factory :subtipo do
-    nombre            { "Subtipo #{ Faker::Name.last_name } #{ FactoryGirl.generate(:n_unico) }" }
+    nombre            { "Subtipo #{ FFaker::Name.last_name } #{ FactoryGirl.generate(:n_unico) }" }
     nombre_corto      { |s| s.nombre.sub('Subtipo ', '') }
     nombre_completo   { |s| "#{ s.nombre } completo" }
     permalink         { |s| s.nombre_corto.tag2url }

--- a/spec/factories/tema.rb
+++ b/spec/factories/tema.rb
@@ -23,7 +23,7 @@ FactoryGirl.define do
 
     factory :tema_titular do
       fecha_titulares { 10.minutes.ago }
-      descripcion     { Faker::Lorem.sentences.join("/r/n") }
+      descripcion     { FFaker::Lorem.sentences.join("/r/n") }
     end
   end
 end

--- a/spec/factories/tematica.rb
+++ b/spec/factories/tematica.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :tematica do
-    nombre        { Faker::Lorem.word }
-    seccion_publi { Faker::Lorem.word }
+    nombre        { FFaker::Lorem.word }
+    seccion_publi { FFaker::Lorem.word }
   end
 end

--- a/spec/factories/usuario.rb
+++ b/spec/factories/usuario.rb
@@ -2,11 +2,11 @@
 
 FactoryGirl.define do
   factory :usuario do
-    nombre            { Faker::Name.first_name }
-    apellidos         { Faker::Name.last_name }
-    nick              { |u| "a" + Faker::Internet.user_name(u.nombre)[0..12]+SecureRandom.hex(3) }
+    nombre            { FFaker::Name.first_name }
+    apellidos         { FFaker::Name.last_name }
+    nick              { |u| "a" + FFaker::Internet.user_name(u.nombre)[0..12]+SecureRandom.hex(3) }
     nick_limpio       { |u| u.nick.tag2url }
-    email             { Faker::Internet.email }
+    email             { FFaker::Internet.email }
     password          "123456"
     pass_sha          "7c4a8d09ca3762af61e59520943dc26494f8941b" # El resultado de codificar 123456
     pais_id           { 1 }

--- a/spec/helpers/news_tematica/application_helper_spec.rb
+++ b/spec/helpers/news_tematica/application_helper_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 describe NewsTematica::ApplicationHelper, type: :helper do
   describe "link_to_con_estadisticas" do
     let(:redirection_class) { ::NewsTematica::Clases.redirection_extern.constantize }
-    let(:mi_news_tematica) { FactoryGirl.create(:news_tematica) }
+    let(:mi_news_tematica) { create(:news_tematica) }
     let(:request) {
       request = double('source')
       allow(request).to receive(:host).and_return('test.host')

--- a/spec/models/news_tematica/news_tematica_spec.rb
+++ b/spec/models/news_tematica/news_tematica_spec.rb
@@ -1,39 +1,39 @@
 require 'spec_helper'
 
 describe NewsTematica do
-  let(:tematica) { FactoryGirl.create(:tematica) }
+  let(:tematica) { create(:tematica) }
 
   describe "calcula_fecha_desde" do
     before { allow(Time).to receive(:now).and_return(Time.parse('Feb 24 2013')) }
 
     it "debe devolver 'hace una semana' si no hay news anteriores de esta temática" do
-      news = FactoryGirl.build(:news_tematica)
+      news = build(:news_tematica)
       news.calcula_fecha_desde
       expect(news.fecha_desde).to eq Time.parse('Feb 17 2013')
     end
 
     it "debe devolver 'hace una semana' si la última news de esta temática es antigua" do
-      FactoryGirl.create(:news_tematica, tematica: tematica, fecha_hasta: Time.parse("Feb 03 2013"))
-      FactoryGirl.create(:news_tematica, tematica: tematica, fecha_hasta: Time.parse("Feb 01 2013"))
-      FactoryGirl.create(:news_tematica, fecha_hasta: Time.parse("Feb 22 2013"))
-      news = FactoryGirl.build(:news_tematica, tematica: tematica)
+      create(:news_tematica, tematica: tematica, fecha_hasta: Time.parse("Feb 03 2013"))
+      create(:news_tematica, tematica: tematica, fecha_hasta: Time.parse("Feb 01 2013"))
+      create(:news_tematica, fecha_hasta: Time.parse("Feb 22 2013"))
+      news = build(:news_tematica, tematica: tematica)
       news.calcula_fecha_desde
       expect(news.fecha_desde).to eq Time.parse('Feb 17 2013')
     end
 
     it "debe devolver la fecha_hasta de la última news de esta temática, si es reciente y está enviada" do
-      FactoryGirl.create(:news_tematica, tematica: tematica, fecha_hasta: Time.parse("Feb 20 2013"), enviada: false)
-      FactoryGirl.create(:news_tematica, tematica: tematica, fecha_hasta: Time.parse("Feb 19 2013"), enviada: true)
-      FactoryGirl.create(:news_tematica, tematica: tematica, fecha_hasta: Time.parse("Feb 18 2013"), enviada: true)
-      FactoryGirl.create(:news_tematica, fecha_hasta: Time.parse("Feb 22 2013"), enviada: true)
-      news = FactoryGirl.build(:news_tematica, tematica: tematica)
+      create(:news_tematica, tematica: tematica, fecha_hasta: Time.parse("Feb 20 2013"), enviada: false)
+      create(:news_tematica, tematica: tematica, fecha_hasta: Time.parse("Feb 19 2013"), enviada: true)
+      create(:news_tematica, tematica: tematica, fecha_hasta: Time.parse("Feb 18 2013"), enviada: true)
+      create(:news_tematica, fecha_hasta: Time.parse("Feb 22 2013"), enviada: true)
+      news = build(:news_tematica, tematica: tematica)
       news.calcula_fecha_desde
       expect(news.fecha_desde).to eq Time.parse('Feb 19 2013')
     end
 
     it "debe devolver 'hace una semana', si la única reciente no está enviada" do
-      FactoryGirl.create(:news_tematica, tematica: tematica, fecha_hasta: Time.parse("Feb 20 2013"), enviada: false)
-      news = FactoryGirl.build(:news_tematica, tematica: tematica)
+      create(:news_tematica, tematica: tematica, fecha_hasta: Time.parse("Feb 20 2013"), enviada: false)
+      news = build(:news_tematica, tematica: tematica)
       news.calcula_fecha_desde
       expect(news.fecha_desde).to eq Time.parse('Feb 17 2013')
     end

--- a/spec/models/news_tematica/news_tematica_spec.rb
+++ b/spec/models/news_tematica/news_tematica_spec.rb
@@ -59,7 +59,7 @@ describe NewsTematica do
 
       before do
         allow(news_tematica)
-          .to receive_message_chain(:suscribible, :suscripciones, :find_in_batches)
+          .to receive_message_chain(:suscribible, :suscripciones, :activas, :find_in_batches)
           .and_yield(suscripciones)
       end
 
@@ -78,7 +78,7 @@ describe NewsTematica do
       it_behaves_like 'news con estado de envío'
 
       before do
-        allow(news_tematica).to receive_message_chain(:suscribible, :suscripciones)
+        allow(news_tematica).to receive_message_chain(:suscribible, :suscripciones, :activas)
           .and_return(Suscribir::Suscripcion.none)
       end
 

--- a/spec/support/factory_girl.rb
+++ b/spec/support/factory_girl.rb
@@ -1,0 +1,7 @@
+RSpec.configure do |config|
+  # Avoid the need to explicit call FactoryGirl for building/creating factories
+  config.include FactoryGirl::Syntax::Methods
+
+  # Avoid errors of Factories with associations when using Rails preloaders
+  config.before(:suite) { FactoryGirl.reload }
+end


### PR DESCRIPTION
As part of [Trello task](https://trello.com/c/RqlIP4NA/37-no-enviar-emails-a-suscripciones-con-activo-false) I had to filter the news tematica to be sent filtering by active subscriptions.