### PR TITLE
Bug/dont send a newsletter twice

### DIFF
--- a/app/models/news_tematica/news_tematica.rb
+++ b/app/models/news_tematica/news_tematica.rb
@@ -25,11 +25,21 @@ module NewsTematica
     end
 
     def enviar!
-      suscribible.suscripciones.activas.en_dominio(dominio_de_envio).find_in_batches do |grupo_suscripciones|
+      destinatarios.find_in_batches do |grupo_suscripciones|
         enviar_a(grupo_suscripciones)
         sleep(1)
       end
       update_attribute(:enviada, true)
+    end
+
+    def destinatarios
+      q = suscribible.suscripciones.activas.en_dominio(dominio_de_envio)
+      q.where("NOT EXISTS (SELECT s.email 
+                             FROM suscribir_suscripciones AS s 
+                            WHERE s.email = suscribir_suscripciones.email
+                              AND s.suscribible_id = suscribir_suscripciones.suscribible_id
+                              AND s.suscribible_type = suscribir_suscripciones.suscribible_type
+                              AND s.id < suscribir_suscripciones.id)")
     end
 
     def enviar_preview_a!(yo)

--- a/app/models/news_tematica/news_tematica.rb
+++ b/app/models/news_tematica/news_tematica.rb
@@ -34,8 +34,8 @@ module NewsTematica
 
     def destinatarios
       q = suscribible.suscripciones.activas.en_dominio(dominio_de_envio)
-      q.where("NOT EXISTS (SELECT s.email 
-                             FROM suscribir_suscripciones AS s 
+      q.where("NOT EXISTS (SELECT s.email
+                             FROM suscribir_suscripciones AS s
                             WHERE s.email = suscribir_suscripciones.email
                               AND s.suscribible_id = suscribir_suscripciones.suscribible_id
                               AND s.suscribible_type = suscribir_suscripciones.suscribible_type

--- a/spec/models/news_tematica/news_tematica_spec.rb
+++ b/spec/models/news_tematica/news_tematica_spec.rb
@@ -1,7 +1,25 @@
 require 'spec_helper'
 
 describe NewsTematica do
-  let(:tematica) { create(:tematica) }
+  let(:tematica) { build_stubbed(:tematica) }
+
+  describe '#destinatarios' do
+    context 'de una news que se envía a todos los dominios' do
+      let(:news) { build(:news_tematica, suscribible: tematica, dominio_de_envio: nil) }
+
+      context 'con alguien suscrito a ese suscribible desde varios dominios' do
+        let(:alguien) { build_stubbed(:usuario) }
+        before do
+          create(:suscripcion, suscriptor: alguien, suscribible: tematica, dominio_de_alta: 'es')
+          create(:suscripcion, suscriptor: alguien, suscribible: tematica, dominio_de_alta: 'mx')
+        end
+
+        it 'debe recibir un solo email de esta news' do
+          expect(news.destinatarios.pluck(:email)).to eq([alguien.email])
+        end
+      end
+    end
+  end
 
   describe 'calcula_fecha_desde' do
     before { allow(Time).to receive(:now).and_return(Time.parse('Feb 24 2013')) }
@@ -59,7 +77,7 @@ describe NewsTematica do
 
       before do
         allow(news_tematica)
-          .to receive_message_chain(:suscribible, :suscripciones, :activas, :en_dominio, :find_in_batches)
+          .to receive_message_chain(:destinatarios, :find_in_batches)
           .and_yield(suscripciones)
       end
 

--- a/test/dummy/app/models/tematica.rb
+++ b/test/dummy/app/models/tematica.rb
@@ -2,32 +2,9 @@ class Tematica < ActiveRecord::Base
   validates :nombre, presence: true
   validates :seccion_publi, presence: true
 
-  ID_GENERAL = 0
-  NOMBRE_GENERAL = 'General'
+  include Suscribir::Suscribible
 
   def to_param
     "#{id}-#{nombre.tag2url}"
-  end
-
-  def self.datos_dropdown
-    self.dame_todas_sin_general
-  end
-
-  def self.dame_general
-    Tematica.find_or_create_by nombre: NOMBRE_GENERAL
-  end
-
-  def self.dame_todas_sin_general
-    tematicas = mi_cache('tematicas')
-    tematicas.select { |tematica| tematica.nombre != NOMBRE_GENERAL }
-  end
-
-  def self.nombre(id, nombre_si_no_se_encuentra = 'temática desconocida')
-    tematica = mi_cache('tematicas').select{ |t| t.id == id.to_i }.first
-    tematica ? tematica.nombre : nombre_si_no_se_encuentra
-  end
-
-  def self.nombre_suscripcion(id)
-    id.to_i == ID_GENERAL ? 'Newsletter General' : nombre(id)
   end
 end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -1512,6 +1512,7 @@ ActiveRecord::Schema.define(version: 20150323131307) do
     t.string   "texto"
     t.integer  "tag_id"
     t.integer  "subtipo_id"
+    t.integer  "suscripciones_count"
     t.string   "seccion_titulares"
     t.string   "scope_mas_leido"
   end


### PR DESCRIPTION
Trello task: Cuando se manda un NewsletterGeneral para todos los dominios y existe un usuario suscrito en varios dominios. Este recibe varios mails. https://trello.com/c/nVXm2cDv/678-3-r-cuando-se-manda-un-newslettergeneral-para-todos-los-dominios-y-existe-un-usuario-suscrito-en-varios-dominios-este-recibe-var

I've isolated, tested & fixed the `destinatarios` querying, to ensure not to send the newsletter twice to the same email.

The current query could be painfully slow, so I've tried in console with real data, and in fact it performs well (better than I expected), so I'm leaving it as is.
