### PR TITLE
Feature/latamize remitente

### DIFF
--- a/app/models/news_tematica/news_tematica.rb
+++ b/app/models/news_tematica/news_tematica.rb
@@ -68,7 +68,7 @@ module NewsTematica
       message = {
         subject: titulo,
         from_name: ESTA_WEB,
-        from_email: ConstantesEmail::INFO,
+        from_email: decorate.remitente,
         to: suscripciones.map { |suscripcion| { email: suscripcion.email } },
         html: html,
         merge_vars: vars_para_newsletter(suscripciones),

--- a/app/views/news_tematica/news_tematicas/_preview.sass.haml
+++ b/app/views/news_tematica/news_tematicas/_preview.sass.haml
@@ -143,8 +143,8 @@
       font-size: 30px
       padding: 10px 0 0
       a
-        text-decoration: none
-        color: $naranja
+        text-decoration: underline
+        color: #FFF
     .mail
       text-align: right
       a


### PR DESCRIPTION
We were on doubt about sending from info@rankia.mx or from info.mx@rankia.com, but we've finally agreed to send from info.mx@rankia.com , like the "contacto" link on the footer

Also improving the contrast of the link, orange over blue hadn't enough contrast

![captura de pantalla 2015-10-29 a la s 10 37 49](https://cloud.githubusercontent.com/assets/103583/10814938/3a499922-7e29-11e5-83b1-46a3c43329dd.png)
![captura de pantalla 2015-10-29 a la s 10 38 21](https://cloud.githubusercontent.com/assets/103583/10814939/3a4d69e4-7e29-11e5-9305-41fdcec0f352.png)
